### PR TITLE
:bug::wrench: fix cms config to generate editorial slug with semester

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -91,7 +91,7 @@ collection_types:
     reverse: true
     extension: 'md'
     format: 'yaml-frontmatter'
-    slug: '{{slug}}'
+    slug: '{{semester}}-{{slug}}'
     editor:
       preview: false
     fields:


### PR DESCRIPTION
do we need to do anything on the editorial `widget` to make it work? @leonardodino — perhaps some validation?